### PR TITLE
build XS is broken on Mac OS X

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -170,7 +170,7 @@ my %opts = (
     },
 );
 
-push @{ $opts{'DIR'} }, 'xs' if $TT_XS_ENABLE;
+push @{ $opts{'DIR'} }, './xs' if $TT_XS_ENABLE;
 
 # Handle dev versions in our check
 my $mmv = $ExtUtils::MakeMaker::VERSION;


### PR DESCRIPTION
it is not understand why, "make" does not take "cd xs", but work with:

```
cd ./xs
```

steps to reproduce:

```
$ git clone https://github.com/abw/Template2.git; cd Template2
...

$ perl Makefile.PL
...
Do you want to build the XS Stash module? [y] y
Do you want to use the XS Stash by default? [y] y 

Checking if your kit is complete...
Looks good
Checking if your kit is complete...
Looks good
Writing Makefile for Template::Stash::XS
Writing Makefile for Template

Configuration complete.  You should now run 'make', 'make test' and
then 'make install'.   See the README file for further information. ...

$ make
...
/bin/sh: line 0: cd: xs: No such file or directory
make: *** [subdirs] Error 1
```

make version:

```
$ make --version
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for i386-apple-darwin11.0
```

also, new Makefile.PL tested on ubuntu 12.04 (successfully build)
