### PR TITLE
Plugin::Date to accept "T" in ISO8601 dates

### DIFF
--- a/lib/Template/Plugin/Date.pm
+++ b/lib/Template/Plugin/Date.pm
@@ -98,7 +98,7 @@ sub format {
         # otherwise, we try to parse it as either a 'Y:M:D H:M:S' or a
         # 'H:M:S D:M:Y' string
 
-        my @parts = (split(/(?:\/| |:|-)/, $time));
+        my @parts = (split(/\D/, $time));
 
         if (@parts >= 6) {
             if (length($parts[0]) == 4) {

--- a/t/date.t
+++ b/t/date.t
@@ -261,3 +261,10 @@ not testing
 -%]
 -- expect --
 12:59
+
+-- test --
+[% USE date;
+   date.format('2001/09/30T12:59:00', '%H:%M')
+-%]
+-- expect --
+12:59


### PR DESCRIPTION
t would nice if Plugin::Date could accept dates with a "T" as the separator like ISO8601 dates: 

2012-09-30T12:59:00 

http://en.wikipedia.org/wiki/I SO_8601 

I opened an RT bug on CPAN with this same request.

https://rt.cpan.org/Ticket/Display.html?id=78065

Thanks!
