### PR TITLE
fix TT2 for perl 5.18

### DIFF
--- a/lib/Template/Plugin/Image.pm
+++ b/lib/Template/Plugin/Image.pm
@@ -157,7 +157,7 @@ sub tag {
     my $options = ref $_[0] eq 'HASH' ? shift : { @_ };
 
     my $tag = '<img src="' . $self->name() . '" ' . $self->attr();
- 
+
     # XHTML spec says that the alt attribute is mandatory, so who
     # are we to argue?
 
@@ -165,8 +165,8 @@ sub tag {
         unless defined $options->{ alt };
 
     if (%$options) {
-        while (my ($key, $val) = each %$options) {
-            my $escaped = escape( $val );
+        for my $key (sort keys %$options) {
+            my $escaped = escape( $options->{$key} );
             $tag .= qq[ $key="$escaped"];
         }
     }


### PR DESCRIPTION
Perl 5.18 will more aggressively randomize hash ordering.  The tests
for the "tag" feature of the Image plugin assume a predictable
ordering of any requested extra tag attributes, and so sometimes
(often) fail.

This patch fixes the problem by sorting the keys in the actual
output.  Although it would be better to alter the tests, to avoid
affecting the code or its performance, the tests are somewhat
complex, and I am guessing that the performance impact of this sort
will be, in practice, negligible.
