### PR TITLE
Pod::Simple compliance

### DIFF
--- a/lib/Template/Manual/Credits.pod
+++ b/lib/Template/Manual/Credits.pod
@@ -13,6 +13,8 @@
 #
 #========================================================================
 
+=encoding utf8
+
 =head1 NAME
 
 Template::Manual::Credits - Author and contributor credits

--- a/lib/Template/Manual/Filters.pod
+++ b/lib/Template/Manual/Filters.pod
@@ -13,6 +13,8 @@
 #
 #========================================================================
 
+=encoding latin1
+
 =head1 NAME
 
 Template::Manual::Filters - Standard filters

--- a/lib/Template/Service.pm
+++ b/lib/Template/Service.pm
@@ -514,7 +514,7 @@ for all uncaught exceptions.
         ERROR => 'error.html'
     });
 
-If the L<ERROR/ERRORS|Template::Manual::Config#ERROR> item is a hash reference
+If the L<ERROR or ERRORS|Template::Manual::Config#ERROR> item is a hash reference
 the keys are assumed to be exception types and the relevant template for a
 given exception will be selected. A C<default> template may be provided for
 the general case.


### PR DESCRIPTION
This commit fixes three files that nowadays generate warnings with recent versions of Pod::Simple. Fixes also https://rt.cpan.org/Ticket/Display.html?id=78731
