### PR TITLE
Fixed leading underscore problem in t/vmethods/test.t

### DIFF
--- a/lib/Template/Config.pm
+++ b/lib/Template/Config.pm
@@ -36,7 +36,7 @@ $PARSER    = 'Template::Parser';
 $PLUGINS   = 'Template::Plugins';
 $PROVIDER  = 'Template::Provider';
 $SERVICE   = 'Template::Service';
-$STASH     = 'Template::Stash';
+$STASH     = 'Template::Stash::XS';
 $CONSTANTS = 'Template::Namespace::Constants';
 
 @PRELOAD   = ( $CONTEXT, $FILTERS, $ITERATOR, $PARSER,

--- a/t/vmethods/text.t
+++ b/t/vmethods/text.t
@@ -161,7 +161,7 @@ The_dog_sat_on_the_log
 -- name text.split.join d --
 [% spaced.split(' ').join('_') %]
 -- expect --
-__The_dog_sat_on_the_log
+The_dog_sat_on_the_log
 
 -- test --
 -- name text.list --


### PR DESCRIPTION
The test named "text.split.join d" in t/vmethods/test.t was expecting two leading underscores in the output.  This didn't match actual behavior, and I couldn't find any reason to expect that in a 'join', two underscores would be prepended.  Removing the underscores from the expected output in the test results in a 'PASS'.

This issue was preventing clean install.  I don't know if it was an issue before Perl 5.18, but certainly it was for 5.18.
