### PR TITLE
Fix split for Perl 5.18.0

### DIFF
--- a/lib/Template/VMethods.pm
+++ b/lib/Template/VMethods.pm
@@ -254,21 +254,21 @@ sub text_split {
     my ($str, $split, $limit) = @_;
     $str = '' unless defined $str;
 
-    # we have to be very careful about spelling out each possible
-    # combination of arguments because split() is very sensitive
-    # to them, for example C<split(' ', ...)> behaves differently
-    # to C<$space=' '; split($space, ...)>
+    # split's behavior changed in Perl 5.18.0 making this:
+    # C<$space=' '; split($space, ...)>
+    # behave the same as this:
+    # C<split(' ', ...)>
+    # qr// behaves the same, so use that for user-defined split.
 
-    if (defined $limit) {
-        return [ defined $split
-                 ? split($split, $str, $limit)
-                 : split(' ', $str, $limit) ];
+    my $split_re;
+    if (defined $split) {
+        eval {
+            $split_re = qr/$split/;
+        };
     }
-    else {
-        return [ defined $split
-                 ? split($split, $str)
-                 : split(' ', $str) ];
-    }
+    $split_re = ' ' unless defined $split_re;
+    $limit ||= 0;
+    return split($split_re, $str, $limit);
 }
 
 sub text_chunk {


### PR DESCRIPTION
Template fails to pass the t/vmethods/text.t test under Perl 5.18.0. This patch rewrites split handling to use qr// which is consistent before and after the Perl 5.18.0 changes.

In perldelta 5.18.0 it reads:

split's first argument is more consistently interpreted

After some changes earlier in v5.17, split's behavior has been
simplified: if the PATTERN argument evaluates to a string containing
one space, it is treated the way that a literal string containing
one space once was.

It seems unwise to me but is possible that you'd want to let TT expose the underlying differences in Perl's implementation, in which case I did an alternative patch that just makes the test avoid differences in Perl. That's at https://github.com/jonjensen/Template2/commit/e564a2e6247ab74f42b660ff322680e51fae3532
