### PR TITLE
Return split results as arrayref instead of list

### DIFF
--- a/lib/Template/VMethods.pm
+++ b/lib/Template/VMethods.pm
@@ -268,7 +268,7 @@ sub text_split {
     }
     $split_re = ' ' unless defined $split_re;
     $limit ||= 0;
-    return split($split_re, $str, $limit);
+    return [split($split_re, $str, $limit)];
 }
 
 sub text_chunk {


### PR DESCRIPTION
Andy, sorry but I just noticed I made an inadvertent change in that 5.18.0 split fit.

In 0caac1347e2e3f2fc290f0a4ffc0281b5df68abb I accidentally changed the return behavior from arrayref to list, which worked fine, but could be slower when large lists are returned and in any case was an unintended change.
