### PR TITLE
Fixed UTF-8 encoding in URLs in URL plugin.

### DIFF
--- a/lib/Template/Plugin/URL.pm
+++ b/lib/Template/Plugin/URL.pm
@@ -23,6 +23,7 @@ use strict;
 use warnings;
 use base 'Template::Plugin';
 
+use utf8;
 our $VERSION = 2.74;
 our $JOINT   = '&amp;';
 
@@ -76,6 +77,7 @@ sub args {
 sub escape {
     my $toencode = shift;
     return undef unless defined($toencode);
+    utf8::encode($toencode);
     $toencode=~s/([^a-zA-Z0-9_.-])/uc sprintf("%%%02x",ord($1))/eg;
     return $toencode;
 }

--- a/t/url.t
+++ b/t/url.t
@@ -15,6 +15,7 @@
 #
 #========================================================================
 
+use utf8;
 use strict;
 use lib qw( ../lib );
 use Template qw( :status );
@@ -178,3 +179,10 @@ there?age=42&amp;name=frank
 -- expect --
 /product?action=edit&style=editor
 /product?action=edit&style=compact
+
+-- test --
+[% USE url('/cgi-bin/woz.pl') -%]
+[% url(utf8="Naïve Unicode") %]
+
+-- expect --
+/cgi-bin/woz.pl?utf8=Na%C3%AFve%20Unicode


### PR DESCRIPTION
Only by encoding the incoming URL part to octets does URL encoding work
correctly. Without this, valid UTF-8 in query parameters, for example, turns
into nonsense when encoded and will be invalid when decoded.
