### PR TITLE
Remove indenting within compiled templates

### DIFF
--- a/lib/Template/Document.pm
+++ b/lib/Template/Document.pm
@@ -243,12 +243,10 @@ sub as_perl {
     my ($class, $content) = @_;
     my ($block, $defblocks, $metadata) = @$content{ qw( BLOCK DEFBLOCKS METADATA ) };
 
-    $block =~ s/\n(?!#line)/\n    /g;
     $block =~ s/\s+$//;
 
     $defblocks = join('', map {
         my $code = $defblocks->{ $_ };
-        $code =~ s/\n(?!#line)/\n        /g;
         $code =~ s/\s*$//;
         "        '$_' => $code,\n";
     } keys %$defblocks);


### PR DESCRIPTION
If a template contains a multiline string, within for example a call to a Locale::gettext template function for translation, then the compiled version of the string written to the compiled template file will contain extra indent whitespace due to the regular expressions within the as_perl() function. For example, the template fragment:

```
[% loc("This is a
multiline string.") %]
```

will be written to the compiled file as something like (note indentation):

```
Template::Document->new({
...
    BLOCK => sub {
...
        eval { BLOCK: {
...
    $output .=  $stash->get(['loc', [ 'This is a
    multiline string.' ]]);
```

This means that - once a compiled template is loaded in, after say a server restart - the translation stops working because the original string does not exactly match the translation string.

The indentation appears to be optional, and is only within compiled template files, so this commit simply removes it.
