### PR TITLE
Handle platforms without LC_ALL/setlocale defined.

### DIFF
--- a/lib/Template/Plugin/Date.pm
+++ b/lib/Template/Plugin/Date.pm
@@ -26,6 +26,10 @@ use base 'Template::Plugin';
 
 use POSIX ();
 
+use Config ();
+
+use constant HAS_SETLOCALE => $Config::Config{d_setlocale};
+
 our $VERSION = 2.78;
 our $FORMAT  = '%H:%M:%S %d-%b-%Y';    # default strftime() format
 our @LOCALE_SUFFIX = qw( .ISO8859-1 .ISO_8859-15 .US-ASCII .UTF-8 );
@@ -124,19 +128,23 @@ sub format {
     if ($locale) {
         # format the date in a specific locale, saving and subsequently
         # restoring the current locale.
-        my $old_locale = &POSIX::setlocale(&POSIX::LC_ALL);
+        my $old_locale = HAS_SETLOCALE
+                       ? &POSIX::setlocale(&POSIX::LC_ALL)
+                       : undef;
 
         # some systems expect locales to have a particular suffix
         for my $suffix ('', @LOCALE_SUFFIX) {
             my $try_locale = $locale.$suffix;
-            my $setlocale = &POSIX::setlocale(&POSIX::LC_ALL, $try_locale);
+            my $setlocale = HAS_SETLOCALE
+                       ? &POSIX::setlocale(&POSIX::LC_ALL, $try_locale)
+                       : undef;
             if (defined $setlocale && $try_locale eq $setlocale) {
                 $locale = $try_locale;
                 last;
             }
         }
         $datestr = &POSIX::strftime($format, @date);
-        &POSIX::setlocale(&POSIX::LC_ALL, $old_locale);
+        &POSIX::setlocale(&POSIX::LC_ALL, $old_locale) if HAS_SETLOCALE;
     }
     else {
         $datestr = &POSIX::strftime($format, @date);

--- a/t/date.t
+++ b/t/date.t
@@ -21,6 +21,7 @@ use Template;
 use Template::Test;
 use Template::Plugin::Date;
 use POSIX;
+use Config;
 $^W = 1;
 
 eval "use Date::Calc";
@@ -58,19 +59,23 @@ my $params = {
 
 sub time_locale { 
     my ($time, $format, $locale) = @_;
-    my $old_locale = &POSIX::setlocale(&POSIX::LC_ALL);
+    my $old_locale = $Config{d_setlocale}
+                   ? &POSIX::setlocale(&POSIX::LC_ALL)
+                   : undef;
     
     # some systems expect locales to have a particular suffix
     for my $suffix ('', @Template::Plugin::Date::LOCALE_SUFFIX) {
         my $try_locale = $locale.$suffix;
-	    my $setlocale = &POSIX::setlocale(&POSIX::LC_ALL, $try_locale);
+	    my $setlocale = $Config{d_setlocale}
+                          ? &POSIX::setlocale(&POSIX::LC_ALL, $try_locale)
+                          : undef;
         if (defined $setlocale && $try_locale eq $setlocale) {
             $locale = $try_locale;
             last;
         }
     }
     my $datestr = &POSIX::strftime($format, localtime($time));
-    &POSIX::setlocale(&POSIX::LC_ALL, $old_locale);
+    &POSIX::setlocale(&POSIX::LC_ALL, $old_locale) if $Config{d_setlocale};
     return $datestr;
 }
 


### PR DESCRIPTION
On Android (and any perl built with -Ud_setlocale), Template::Plugin::Date
and its tests cause errors because neither setlocale() nor the
locale-related constants are defined, so we need
to protect those calls by checking what %Config has to say.
