### PR TITLE
Silence some warnings

### DIFF
--- a/xs/Stash.xs
+++ b/xs/Stash.xs
@@ -34,10 +34,11 @@ extern "C" {
 #define PERL_NO_GET_CONTEXT
 #include "EXTERN.h"
 #include "perl.h"
+#include "XSUB.h"
+
 #define NEED_sv_2pv_flags
 #define NEED_newRV_noinc
 #include "ppport.h"
-#include "XSUB.h"
 
 #ifdef __cplusplus
 }
@@ -161,6 +162,9 @@ static TT_RET tt_fetch_item(pTHX_ SV *root, SV *key_sv, AV *args, SV **result) {
       case SVt_PVAV:
         if (looks_like_number(key_sv))
             value = av_fetch((AV *) SvRV(root), SvIV(key_sv), FALSE);
+        break;
+
+      default:
         break;
     }
 


### PR DESCRIPTION
`ppport.h` should be included after `XSUB.h`, otherwise (atleast on OSX you get this):

```
In file included from Stash.xs:40:
/Users/jacques/perl/lib/darwin/CORE/XSUB.h:158:9: warning: 'dAX' macro redefined
#define dAX const I32 ax = (I32)(MARK - PL_stack_base + 1)
        ^
./ppport.h:4073:11: note: previous definition is here
#  define dAX                            I32 ax = MARK - PL_stack_base + 1
          ^
In file included from Stash.xs:40:
/Users/jacques/perl/lib/darwin/CORE/XSUB.h:160:9: warning: 'dAXMARK' macro redefined
#define dAXMARK                         \
        ^
./ppport.h:4083:11: note: previous definition is here
#  define dAXMARK                        I32 ax = POPMARK; \
          ^
In file included from Stash.xs:40:
/Users/jacques/perl/lib/darwin/CORE/XSUB.h:164:9: warning: 'dITEMS' macro redefined
#define dITEMS I32 items = (I32)(SP - MARK)
        ^
./ppport.h:4077:11: note: previous definition is here
#  define dITEMS                         I32 items = SP - MARK
          ^
In file included from Stash.xs:40:
/Users/jacques/perl/lib/darwin/CORE/XSUB.h:175:9: warning: 'dXSTARG' macro redefined
#define dXSTARG SV * const targ = ((PL_op->op_private & OPpENTERSUB_HASTARG) \
        ^
./ppport.h:4080:11: note: previous definition is here
#  define dXSTARG                        SV * targ = sv_newmortal()
          ^
In file included from Stash.xs:40:
/Users/jacques/perl/lib/darwin/CORE/XSUB.h:198:9: warning: 'UNDERBAR' macro redefined
#define UNDERBAR  find_rundefsv()
        ^
./ppport.h:4070:11: note: previous definition is here
#  define UNDERBAR                       DEFSV
          ^
Stash.xs:156:13: warning: 15 enumeration values not handled in switch: 'SVt_NULL', 'SVt_BIND', 'SVt_IV'... [-Wswitch]
    switch (SvTYPE(SvRV(root))) {
            ^
/Users/jacques/perl/lib/darwin/CORE/sv.h:288:20: note: expanded from macro 'SvTYPE'
#define SvTYPE(sv)      ((svtype)((sv)->sv_flags & SVTYPEMASK))
                        ^
6 warnings generated.
```

Also added a `default` to one of the `switch()` statements.
