### PR TITLE
Fixing warnings in list_nsort when sorting by multiple fields.

### DIFF
--- a/lib/Template/VMethods.pm
+++ b/lib/Template/VMethods.pm
@@ -569,17 +569,19 @@ sub list_sort {
 sub list_nsort {
     my ($list, @fields) = @_;
     return $list unless @$list > 1;     # no need to sort 1 item lists
-    return [
-        @fields                         # Schwartzian Transform
-        ?  map  { $_->[0] }             # for case insensitivity
-           sort { $a->[1] <=> $b->[1] }
-           map  { [ $_, _list_sort_make_key($_, \@fields) ] }
-           @$list
-        :  map  { $_->[0] }
-           sort { $a->[1] <=> $b->[1] }
-           map  { [ $_, lc $_ ] }
-           @$list,
-    ];
+
+    my $sort = sub {
+        my $cmp;
+        # compare each field individually
+        for my $field (@fields) {
+            my $A = _list_sort_make_key($a, [ $field ]);
+            my $B = _list_sort_make_key($b, [ $field ]);
+            ($cmp = $A <=> $B) and last;
+        }
+        $cmp;
+    };
+
+    return [ sort $sort @{ $list } ];
 }
 
 sub list_unique {


### PR DESCRIPTION
When sorting a list by multiple numeric keys, many warnings are produced:

```
[% SET things = [
    {
        'foo' => 1,
        'bar' => 1,
    },
    {
        'foo' => 1,
        'bar' => 2,
    },
    {
        'foo' => 2,
        'bar' => 1,
    },
] %]

[% FOREACH thing IN things.nsort("foo", "bar") %]
    [% thing.foo %] [% thing.bar %]
[% END %]
```

> Argument "1/_^unlikely^_/2" isn't numeric in numeric comparison (<=>) at > /usr/lib/perl5/site_perl/5.8.8/i386-linux-thread-multi/Template/VMethods.pm line 574.
> Argument "1/_^unlikely^_/1" isn't numeric in numeric comparison (<=>) at /usr/lib/perl5/site_perl/5.8.8/i386-linux-thread-multi/Template/VMethods.pm line 574.
> Argument "2/_^unlikely^_/1" isn't numeric in numeric comparison (<=>) at /usr/lib/perl5/site_perl/5.8.8/i386-linux-thread-multi/Template/VMethods.pm line 574.
