### PR TITLE
Added testrules.yml to always run compile*.t sequentially

### DIFF
--- a/testrules.yml
+++ b/testrules.yml
@@ -1,0 +1,3 @@
+seq:
+        - seq: t/compile*.t
+        - par: **


### PR DESCRIPTION
Since t/compile1.t creates the cache for the other compile*.t tests, it cannot be run parallel and must be explicitly set to run sequentially.

Fixes RT 99576 and should fix a couple CPAN Tester Reports ([example](http://www.cpantesters.org/cpan/report/3e55a648-91c9-11e4-8169-9f55a5948d86))