### PR TITLE
Add 'empty' vmethods for scalar, list and hash

### DIFF
--- a/lib/Template/Manual/VMethods.pod
+++ b/lib/Template/Manual/VMethods.pod
@@ -6,7 +6,7 @@
 #   Andy Wardley  <abw@wardley.org>
 #
 # COPYRIGHT
-#   Copyright (C) 1996-2007 Andy Wardley.  All Rights Reserved.
+#   Copyright (C) 1996-2015 Andy Wardley.  All Rights Reserved.
 #
 #   This module is free software; you can redistribute it and/or
 #   modify it under the same terms as Perl itself.
@@ -85,6 +85,14 @@ Returns the length of the string representation of the item:
 
     [% IF password.length < 8 %]
        Password too short, dumbass!
+    [% END %]
+
+=head2 empty
+
+Returns true if the string is empty:
+
+    [% IF details.empty %]
+       No details specified
     [% END %]
 
 =head2 list
@@ -401,6 +409,14 @@ Delete one or more items from the hash.
 
 Returns the number of key/value pairs in the hash.
 
+=head2 empty
+
+Returns true if the hash is empty:
+
+    [% IF config.empty %]
+       No configuration available
+    [% END %]
+
 =head2 item
 
 Returns an item from the hash using a key passed as an argument.
@@ -427,6 +443,14 @@ Returns the size of a list (number of elements) and the maximum
 index number (size - 1), respectively.
 
     [% results.size %] search results matched your query
+
+=head2 empty
+
+Returns true if the list is empty:
+
+    [% IF results.empty %]
+       No results found
+    [% END %]
 
 =head2 defined
 

--- a/lib/Template/VMethods.pm
+++ b/lib/Template/VMethods.pm
@@ -9,7 +9,7 @@
 #   Andy Wardley   <abw@wardley.org>
 #
 # COPYRIGHT
-#   Copyright (C) 1996-2006 Andy Wardley.  All Rights Reserved.
+#   Copyright (C) 1996-2015 Andy Wardley.  All Rights Reserved.
 #
 #   This module is free software; you can redistribute it and/or
 #   modify it under the same terms as Perl itself.
@@ -42,6 +42,7 @@ our $TEXT_VMETHODS = {
     hash        => \&text_hash,
     length      => \&text_length,
     size        => \&text_size,
+    empty       => \&text_empty,
     defined     => \&text_defined,
     upper       => \&text_upper,
     lower       => \&text_lower,
@@ -67,6 +68,7 @@ our $HASH_VMETHODS = {
     item    => \&hash_item,
     hash    => \&hash_hash,
     size    => \&hash_size,
+    empty   => \&hash_empty,
     each    => \&hash_each,
     keys    => \&hash_keys,
     values  => \&hash_values,
@@ -91,6 +93,7 @@ our $LIST_VMETHODS = {
     shift   => \&list_shift,
     max     => \&list_max,
     size    => \&list_size,
+    empty   => \&list_empty,
     defined => \&list_defined,
     first   => \&list_first,
     last    => \&list_last,
@@ -146,6 +149,10 @@ sub text_length {
 
 sub text_size {
     return 1;
+}
+
+sub text_empty {
+    return 0 == text_length($_[0]) ? 1 : 0;
 }
 
 sub text_defined {
@@ -364,6 +371,10 @@ sub hash_size {
     scalar keys %{$_[0]};
 }
 
+sub hash_empty {
+    return 0 == hash_size($_[0]) ? 1 : 0;
+}
+
 sub hash_each {
     # this will be changed in TT3 to do what hash_pairs() does
     [ %{ $_[0] } ];
@@ -491,6 +502,10 @@ sub list_size {
     no warnings;
     my $list = shift;
     $#$list + 1;
+}
+
+sub list_empty {
+    return 0 == list_size($_[0]) ? 1 : 0;
 }
 
 sub list_defined {

--- a/t/vmethods/hash.t
+++ b/t/vmethods/hash.t
@@ -6,7 +6,7 @@
 #
 # Written by Andy Wardley <abw@cpan.org>
 #
-# Copyright (C) 1996-2006 Andy Wardley.  All Rights Reserved.
+# Copyright (C) 1996-2015 Andy Wardley.  All Rights Reserved.
 #
 # This is free software; you can redistribute it and/or modify it
 # under the same terms as Perl itself.
@@ -75,6 +75,20 @@ a, b, c, d
 [% hash.size %]
 -- expect --
 2
+
+-- test --
+-- name hash.empty on empty --
+[% empty = { };
+   empty.empty %]
+-- expect --
+1
+
+-- test --
+-- name hash.empty on non-empty --
+[% nonempty = { e => 'f' };
+   nonempty.empty %]
+-- expect --
+0
 
 -- test --
 [% hash.defined('a') ? 'good' : 'bad' %]

--- a/t/vmethods/list.t
+++ b/t/vmethods/list.t
@@ -6,7 +6,7 @@
 #
 # Written by Andy Wardley <abw@cpan.org>
 #
-# Copyright (C) 1996-2006 Andy Wardley.  All Rights Reserved.
+# Copyright (C) 1996-2015 Andy Wardley.  All Rights Reserved.
 #
 # This is free software; you can redistribute it and/or modify it
 # under the same terms as Perl itself.
@@ -133,6 +133,20 @@ woz
 [% metavars.size %]
 -- expect --
 7
+
+-- test --
+-- name list.empty on empty --
+[% empty = [ ];
+   empty.empty %]
+-- expect --
+1
+
+-- test --
+-- name list.empty on non-empty --
+[% nonempty = [ 'e', 'f' ];
+   nonempty.empty %]
+-- expect --
+0
 
 -- test --
 [% empty = [ ];

--- a/t/vmethods/text.t
+++ b/t/vmethods/text.t
@@ -6,7 +6,7 @@
 #
 # Written by Andy Wardley <abw@cpan.org>
 #
-# Copyright (C) 1996-2006 Andy Wardley.  All Rights Reserved.
+# Copyright (C) 1996-2015 Andy Wardley.  All Rights Reserved.
 #
 # This is free software; you can redistribute it and/or modify it
 # under the same terms as Perl itself.
@@ -180,6 +180,20 @@ The cat sat on the mat
 [% string.size %]
 -- expect --
 1
+
+-- test --
+-- name text.empty on empty --
+[% text = '';
+   text.empty %]
+-- expect --
+1
+
+-- test --
+-- name text.empty on non-empty --
+[% text = 'bandanna';
+   text.empty %]
+-- expect --
+0
 
 -- test --
 -- name text.squote --


### PR DESCRIPTION
I often find myself doing things like this:

    [% IF 0 == details.size %]                                                      
       No details specified                                                     
    [% END %] 

For convenience and brevity, it would be nice to have a `scalar` vmethod so that one could instead write

    [% IF details.empty %]                                                      
       No details specified                                                     
    [% END %] 
