### PR TITLE
Make Template::Toolkit a module

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -64,7 +64,7 @@ lib/Template/Stash.pm
 lib/Template/Stash/Context.pm
 lib/Template/Stash/XS.pm
 lib/Template/Test.pm
-lib/Template/Toolkit.pod
+lib/Template/Toolkit.pm
 lib/Template/Tools.pod
 lib/Template/Tools/tpage.pod
 lib/Template/Tools/ttree.pod

--- a/lib/Template/Toolkit.pm
+++ b/lib/Template/Toolkit.pm
@@ -16,6 +16,12 @@
 #
 #========================================================================
 
+package Template::Toolkit;
+
+1;
+
+__END__
+
 =head1 NAME
 
 Template::Toolkit - Template Processing System


### PR DESCRIPTION
(this branch ties in with #32)

It happens fairly often that someone does

  $ cpanm Template::Toolkit

and wonder why CPAN doesn't find the distribution.
Moving the main pod to a `.pm` would index it, and
take care of that.