### PR TITLE
Make truncate Character Entity Reference aware - fixes RT bug 95707

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+sudo: required
+dist: trusty
+language: cpp
+compiler:
+- gcc
+before_install:
+# for gcc with C++11 support
+- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+- sudo apt-get -qq update
+install:
+# install GTest and GMock
+- sudo apt-get -qq install libgtest-dev
+- "cd /usr/src/gtest && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
+- sudo apt-get -qq install google-mock
+- "cd /usr/src/gmock && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
+# update to gcc with C++11 support
+- sudo apt-get -qq install gcc-4.9 g++-4.9
+- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
+- sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.9 90
+- sudo apt-get -qq install libtest-simple-perl
+- sudo apt-get -qq install libtest-harness-perl
+- sudo apt-get -qq install appconfig-perl
+# install latest LCOV (1.9 was failing)
+- cd ${TRAVIS_BUILD_DIR}
+- wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz
+- tar xf lcov_1.11.orig.tar.gz
+- sudo make -C lcov-1.11/ install
+- gem install coveralls-lcov
+- lcov --version
+- g++ --version
+before_script:
+- cd ${TRAVIS_BUILD_DIR}
+# init coverage to 0 (optional)
+- lcov --directory . --zerocounters
+script:
+- cd ${TRAVIS_BUILD_DIR}
+# Check that this works this way
+- perl Makefile.PL TT_XS_ENABLE=y TT_XS_DEFAULT=y TT_ACCEPT=y
+- make
+- make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ install:
 - sudo apt-get -qq install libtest-simple-perl
 - sudo apt-get -qq install libtest-harness-perl
 - sudo apt-get -qq install appconfig-perl
+- sudo apt-get -qq install libcgi-pm-perl
+- sudo apt-get -qq install libimage-size-perl
+- sudo apt-get -qq install libpod-pom-perl
 # install latest LCOV (1.9 was failing)
 - cd ${TRAVIS_BUILD_DIR}
 - wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz

--- a/MANIFEST
+++ b/MANIFEST
@@ -216,7 +216,6 @@ t/tiedhash.t
 t/try.t
 t/unicode.t
 t/url.t
-t/url2.t
 t/vars.t
 t/varsv1.t
 t/view.t
@@ -231,6 +230,7 @@ t/zz-pmv.t
 t/zz-pod-coverage.t
 t/zz-pod-kwalitee.t
 t/zz-stash-xs-leak.t
+t/zz-url2.t
 TODO
 xs/Makefile.PL
 xs/MANIFEST

--- a/lib/Template/Filters.pm
+++ b/lib/Template/Filters.pm
@@ -564,8 +564,16 @@ sub truncate_filter_factory {
     $len  = $TRUNCATE_LENGTH unless defined $len;
     $char = $TRUNCATE_ADDON  unless defined $char;
 
-    # Length of char is the minimum length
     my $lchar = length $char;
+    my $extra = $char;
+    my $CER = '[:#_A-Za-z][:A-Za-z0-9\-\_]+';
+
+    if ($char =~ /\&($CER;)/) {
+      $extra =~ s,\&($CER;),_,g;
+      $lchar = length $extra;
+    }
+
+    # Length of char is the minimum length
     if ($len < $lchar) {
         $char  = substr($char, 0, $len);
         $lchar = $len;

--- a/lib/Template/Manual/Filters.pod
+++ b/lib/Template/Manual/Filters.pod
@@ -323,7 +323,7 @@ second argument.
 
 Output:
 
-    I have much to say&hellip;
+    I have much to say on this&hellip;
 
 =head1 repeat(iterations)
 

--- a/t/filter.t
+++ b/t/filter.t
@@ -975,3 +975,16 @@ foo(bar)
 [% "foo(bar)" | uri %]
 -- expect --
 foo(bar)
+
+-- test --
+[% "I have much to say on this matter that has previously 
+    been said on more than one occasion." | truncate(27,"&hellip;") %]
+-- expect --
+I have much to say on this&hellip;
+
+-- test --
+[% "I have much to say on this matter that has previously 
+    been said on more than one occasion." | truncate(27,"&#x2026;") %]
+-- expect --
+I have much to say on this&#x2026;
+


### PR DESCRIPTION
I have improved the truncate filter to be aware of HTML Character Entity References for the truncate character. Ideally we would do something simular to the input text $context too. This fixes bug 95707 on rt.cpan.org.
This also fixes the minor bug 106340.
