### PR TITLE
Warn on duplicate block name.

### DIFF
--- a/lib/Template/Parser.pm
+++ b/lib/Template/Parser.pm
@@ -744,6 +744,8 @@ sub define_block {
     $self->debug("compiled block '$name':\n$block")
         if $self->{ DEBUG } & Template::Constants::DEBUG_PARSER;
 
+    warn "Block redefined: $name\n" if exists $defblock->{ $name };
+
     $defblock->{ $name } = $block;
 
     return undef;

--- a/t/block_duplicate.t
+++ b/t/block_duplicate.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Template;
+
+my $warning_seen;
+local $SIG{__WARN__} = sub {
+    my @warnings = @_;
+    if ($warnings[0] =~ /Block redefined: b1/) {
+        ++$warning_seen;
+    } else {
+        die "Unexpected warning: ", @warnings;
+    }
+};
+
+my $t = Template->new;
+$t->process(\ << '__TEMPLATE__', {}, \ my $ignore_output);
+[% BLOCK b1 %]first[% END %]
+[% BLOCK b1 %]second[% END %]
+__TEMPLATE__
+
+is $warning_seen, 1, 'warning seen';


### PR DESCRIPTION
Before, Template would silently ignore all previous definitions of the
block.

See also https://github.com/ingydotnet/jemplate/issues/8 .