### PR TITLE
Add Sortkeys to DUMPER_ARGS

### DIFF
--- a/lib/Template/Plugin/Dumper.pm
+++ b/lib/Template/Plugin/Dumper.pm
@@ -27,7 +27,7 @@ use Data::Dumper;
 our $VERSION = 2.70;
 our $DEBUG   = 0 unless defined $DEBUG;
 our @DUMPER_ARGS = qw( Indent Pad Varname Purity Useqq Terse Freezer
-                       Toaster Deepcopy Quotekeys Bless Maxdepth );
+                       Toaster Deepcopy Quotekeys Bless Maxdepth Sortkeys );
 our $AUTOLOAD;
 
 #==============================================================================


### PR DESCRIPTION
This change allows sorting the keys in the output of dumper (convenient when reproducing the same output over and over again during debugging).