### PR TITLE
remove rm external system command call

### DIFF
--- a/t/process_dir.t
+++ b/t/process_dir.t
@@ -21,11 +21,12 @@ use lib qw( ./lib ../lib );
 
 use Template;
 use Test::More;
+use File::Path qw (remove_tree);
 
 my $testdir  = 'testdir';
 my $CACHEDIR = 'ttcache';
 
-`rm -rf $CACHEDIR $testdir`;
+remove_tree("$CACHEDIR", "$testdir");
 
 my $config = {COMPILE_DIR  => $CACHEDIR};
 my $tt1 = Template->new($config);
@@ -38,7 +39,7 @@ EOF
 
 my $expected1 = "file error - $testdir: not found";
 
-my $expected2 = "file error - ./$testdir: not a file";
+my $expected2 = $^O ne 'MSWin32' ? "file error - ./$testdir: not a file" : "file error - $testdir: not a file";
 
 my $expected3 = <<'EOF';
 This is the first test
@@ -77,4 +78,4 @@ is($ret, $expected3, 'Correctly PROCESSed file');
 
 done_testing();
 
-`rm -rf $CACHEDIR $testdir`;
+remove_tree("$CACHEDIR", "$testdir");


### PR DESCRIPTION
Template failed test process_dir.t because external "rm -rf" call is
made in that file. That command doesn't exist on Win32 system. It is
possible to use remove_tree from File::Path. There is also a condition
with expected2 that need some adjustment.

Below error message from test:

'rm' is not recognized as an internal or external command,
operable program or batch file.

#   Failed test 'Error on PROCESSing directory'
#   at t/process_dir.t line 63.
#          got: 'file error - testdir: not a file'
#     expected: 'file error - ./testdir: not a file'
'rm' is not recognized as an internal or external command,
operable program or batch file.
# Looks like you failed 1 test of 5.
t/process_dir.t .......
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/5 subtests

I hope you will agree my pull request. Thanks for that great module.