### PR TITLE
Added Travis-CI Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ perl:
   - "5.14"
   - "5.12"
   - "5.10"
+script:
+  - export PERL_MM_USE_DEFAULT=1 &&  perl Makefile.PL && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 branches:
 language: perl
+env:
+  - PERL_USE_UNSAFE_INC=0
 perl:
   - "5.26"
   - "5.24"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+branches:
+language: perl
+perl:
+  - "5.26"
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"  # IO::Tty is missing on the Travis server or cannot be installed?
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -87,7 +87,7 @@ $TT_XS_DEFAULT    = 'y';
 $TT_QUIET         = 'n';
 $TT_ACCEPT        = 'n';
 
-my $DEFAULTS_FILE   = '.defaults.cfg';
+my $DEFAULTS_FILE   = './.defaults.cfg';
 my $DEFAULTS = '';
 
 if (-f $DEFAULTS_FILE) {

--- a/lib/Template/Config.pm
+++ b/lib/Template/Config.pm
@@ -36,7 +36,7 @@ $PARSER    = 'Template::Parser';
 $PLUGINS   = 'Template::Plugins';
 $PROVIDER  = 'Template::Provider';
 $SERVICE   = 'Template::Service';
-$STASH     = 'Template::Stash';
+$STASH     = 'Template::Stash::XS';
 $CONSTANTS = 'Template::Namespace::Constants';
 
 @PRELOAD   = ( $CONTEXT, $FILTERS, $ITERATOR, $PARSER,


### PR DESCRIPTION
Only non-.travis.yml change was that perl Makefile.pl failed for 5.26 because '.' is pulled from @INC, so I changed '.defaults.cfg' to './.defaults.cfg'