### PR TITLE
Documentation: Fix typo

### DIFF
--- a/lib/Template/Manual/VMethods.pod
+++ b/lib/Template/Manual/VMethods.pod
@@ -153,7 +153,7 @@ appears in the source string, provide a true value for the C<global>
 argument following the pattern.
 
     [% text = 'bandanna';
-       text.match('an+', 1).join(', )      # an, ann
+       text.match('an+', 1).join(', ')      # an, ann
     %]
 
 =head2 repeat(n)
@@ -552,7 +552,7 @@ current list.
        two   = [ 4 5 6 ];
        three = [ 7 8 9 ];
        one.import(two, three);
-       one.join(', );     # 1, 2, 3, 4, 5, 6, 7, 8, 9
+       one.join(', ');     # 1, 2, 3, 4, 5, 6, 7, 8, 9
     %]
 
 =head2 merge


### PR DESCRIPTION
Was:
> join(', )

Now:
> join(', ')