### PR TITLE
Fix relative path handling in templates on Perl 5.26+ with 'do'

### DIFF
--- a/lib/Template/Provider.pm
+++ b/lib/Template/Provider.pm
@@ -562,13 +562,9 @@ sub _compiled_filename {
 
 sub _load_compiled {
     my ($self, $file) = @_;
-    my $compiled;
 
-    # load compiled template via require();  we zap any
-    # %INC entry to ensure it is reloaded (we don't
-    # want 1 returned by require() to say it's in memory)
-    delete $INC{ $file };
-    eval { $compiled = require $file; };
+    my $fpath = File::Spec->rel2abs($file);
+    my $compiled = do $fpath;
     return $@
         ? $self->error("compiled template $compiled: $@")
         : $compiled;


### PR DESCRIPTION
Instead of using a messy delete/eval+require construction, its simpler
just to use "do" which doesn't check %INC in the first place.

do + $@ semantics are the same as requires, and "do" was designed for
this sort of thing.

Additionally, this leads to be able to potentially check the value of
$!, which may be meaningful here.

Additionally, "didn't end with true" is no longer a failure condition
... this may or may not be a good thing.

NB: It doesn't seem like the value of "$compiled" is very useful in the
failure case, as the expectation is with require, that'd have been a
falsey value at best, or a literal "undef" at worst, yeilding additional
warnings.