### PR TITLE
ttree: allow passing STRICT option to Template::->new(...)

### DIFF
--- a/bin/ttree
+++ b/bin/ttree
@@ -632,6 +632,7 @@ sub read_config {
         'template_default|default=s',
         'template_error|error=s',
         'template_debug|debug=s',
+        'template_strict|strict',
         'template_start_tag|start_tag|starttag=s',
         'template_end_tag|end_tag|endtag=s',
         'template_tag_style|tag_style|tagstyle=s',


### PR DESCRIPTION
Hi!

I wanted to use the `STRICT` option of `Template` together with `ttree` but couldn't find a way to do that, so here is a patch that makes it possible to specify the option in `ttreerc`.