### PR TITLE
Check string with index before substitute

### DIFF
--- a/lib/Template/Directive.pm
+++ b/lib/Template/Directive.pm
@@ -209,7 +209,13 @@ sub ident {
         # handler defined?
         if (@$ident > 2 && ($ns = $self->{ NAMESPACE })) {
             my $key = $ident->[0];
-            $key =~ s/^'(.+)'$/$1/s;
+
+            # a faster alternate to $key =~ s/^'(.+)'$/$1/s
+            if ( index( $key, q[']) == 0 ) {
+                substr( $key, 0, 1, '' );
+                substr( $key, -1, 1, '' ); # remove the last char blindly
+            }
+
             if ($ns = $ns->{ $key }) {
                 return $ns->ident($ident);
             }


### PR DESCRIPTION
This is a micro optimization to speedup the
quotes stripping.

From a simple Benchmark::Dumb test it appears to be 25 to 35 %
faster. View GitHub case for benchmark script.

Here is a naive benchmark test proving the speedup advantage of the index usage vs the substr one liner.
```perl
#!perl

use strict;
use warnings;

use Benchmark::Dumb qw(:all);

my @noquotes = qw{some values without quotes};
my @quotes   = qw{'with' 'a' 'quote' 'longworwithaquote'};

for ( 1..10 ) {
	push @noquotes, @noquotes;
	push @quotes, @quotes;	
}

my @mix = @quotes, @noquotes;

print "# Strings with quotes\n";
compare( \@quotes );

print "# Strings without quotes\n";
compare( \@noquotes );

print "# A mixed of both: 50/50\n";
compare( \@mix );

sub compare {
	my ( $input ) = @_;

	cmpthese(
	    0.01,    # 1% precision
	    {   substitute => sub {
	    		my @values = ( @$input );

	    		foreach my $key ( @values ) {
	    			$key =~ s/^'(.+)'$/$1/s;	
	    		}

	            return;
	        },
	        index => sub {
	        	
	        	my @values = ( @$input );

	        	foreach my $key ( @values ) {
		            if ( index( $key, q['] ) == 0 ) {
		                substr( $key, 0,  1, '' );
		                substr( $key, -1, 1, '' );
		            }
	        	}
	            return;
	        },
	    }
	);

}

__END__

# Strings with quotes
                     Rate  substitute  index
substitute 297.31+-0.31/s          -- -34.2%
index      451.64+-0.77/s 51.91+-0.3%     --
# Strings without quotes
                    Rate   substitute  index
substitute  982.8+-3.9/s           -- -23.4%
index      1282.9+-4.4/s 30.53+-0.68%     --
# A mixed of both: 50/50
                     Rate   substitute  index
substitute 297.09+-0.61/s           -- -34.3%
index        451.9+-1.2/s 52.11+-0.51%     --
```