### PR TITLE
Adjust t/filter.t after using RFC3986 as default for URI

### DIFF
--- a/t/filter.t
+++ b/t/filter.t
@@ -945,12 +945,12 @@ fOOBAR
 -- test --
 [% "foo(bar)" | uri %]
 -- expect --
-foo(bar)
+foo%28bar%29
 
 -- test --
 [% "foo(bar)" | url %]
 -- expect --
-foo(bar)
+foo%28bar%29
 
 -- test --
 [% use_rfc3986;


### PR DESCRIPTION
GH #179

With commit b0620f4 we start using RFC3986 as default
for URI but the test was not adjusted according to this
new setting.