### PR TITLE
Template stash  dotop

### DIFF
--- a/lib/Template/Stash.pm
+++ b/lib/Template/Stash.pm
@@ -497,11 +497,9 @@ sub _dotop {
             # real throwing
 
             my $class = ref($root) || $root;
-            # this is very fragile...
-            die $@ if ( ref($@)
-                || ( $] >= 5.019 && ($@ !~ m/Can't locate object method "\Q$item\E" via package "\Q$class\E"/) )
-                || ( $] <= 5.018 && ($@ !~ m/Undefined subroutine/) )
-                );
+
+            # Fail only if the function exists
+            die $@ if ( ref($@) || $root->can($item) );
 
             # failed to call object method, so try some fallbacks
             if (reftype $root eq 'HASH') {

--- a/lib/Template/Stash.pm
+++ b/lib/Template/Stash.pm
@@ -497,7 +497,11 @@ sub _dotop {
             # real throwing
 
             my $class = ref($root) || $root;
-            die $@ if ref($@) || ($@ !~ /Can't locate object method "\Q$item\E" via package "\Q$class\E"/);
+            # this is very fragile...
+            die $@ if ( ref($@)
+                || ( $] >= 5.019 && ($@ !~ m/Can't locate object method "\Q$item\E" via package "\Q$class\E"/) )
+                || ( $] <= 5.018 && ($@ !~ m/Undefined subroutine/) )
+                );
 
             # failed to call object method, so try some fallbacks
             if (reftype $root eq 'HASH') {

--- a/xs/Stash.xs
+++ b/xs/Stash.xs
@@ -100,8 +100,12 @@ static SV*      hash_dot_values(pTHX_ HV*, AV*);
 static SV*      scalar_dot_defined(pTHX_ SV*, AV*);
 static SV*      scalar_dot_length(pTHX_ SV*, AV*);
 
+#if PERL_VERSION >= 19
+
 #define THROW_SIZE 64
 static char throw_fmt[] = "Can't locate object method \"%s\" via package \"%s\"";
+
+#endif
 
 /* dispatch table for XS versions of special "virtual methods",
  * names must be in alphabetical order          
@@ -342,7 +346,9 @@ static SV *dotop(pTHX_ SV *root, SV *key_sv, AV *args, int flags) {
                 SPAGAIN;
                 
                 if (SvTRUE(ERRSV)) {
+#if PERL_VERSION >= 19
                     char throw_str[THROW_SIZE+1];
+#endif
                     (void) POPs;                /* remove undef from stack */
                     PUTBACK;
                     result = NULL;
@@ -365,10 +371,17 @@ static SV *dotop(pTHX_ SV *root, SV *key_sv, AV *args, int flags) {
                          * to fit into throw_str then snprintf() doesn't add the
                          * terminating NULL 
                          */
+#if PERL_VERSION >= 19
                         snprintf(throw_str, THROW_SIZE, throw_fmt, item, HvNAME(stash));
                         throw_str[THROW_SIZE] = '\0';
-
-                        if (! strstr( SvPV(ERRSV, PL_na), throw_str)) 
+#endif
+                        if (
+#if PERL_VERSION >= 19
+                            ! strstr( SvPV(ERRSV, PL_na), throw_str)
+#else
+                            ! strstr( SvPV(ERRSV, PL_na), "Undefined subroutine")
+#endif
+                            )
                             die_object(aTHX_ ERRSV);
                     }
                 } else {


### PR DESCRIPTION

    Discovered this issue while running the test suite
    with travis and realized that t/cgi.t which is now
    using Template::Plugin::Scalar was not working as
    expected for Perl 5.18 and earlier...

    The regexp on $@ is kind of very fragile.

Extend the existing regexp as part of the first commit, then convert it to a 'can' usage
