### PR TITLE
When creating a new document use self's DOCUMENT instead of global

### DIFF
--- a/lib/Template/Provider.pm
+++ b/lib/Template/Provider.pm
@@ -907,7 +907,7 @@ sub _compile {
 
         unless ($error) {
             return $data                                        ## RETURN ##
-                if $data->{ data } = $DOCUMENT->new($parsedoc);
+                if $data->{ data } = $self->{DOCUMENT}->new($parsedoc);
             $error = $Template::Document::ERROR;
         }
     }

--- a/t/provider.t
+++ b/t/provider.t
@@ -251,8 +251,23 @@ my $uselist = [
     ttd2   => $ttd2, 
     ttdbad => $ttd3 ];
 
-test_expect(\*DATA, $uselist, $vars);
+#------------------------------------------------------------------------
+# What about if a DOCUMENT class is specified.
+#------------------------------------------------------------------------
+require "$lib/document.pm" || die $!;
+is $provabs->{DOCUMENT}, 'Template::Document', "Default document class is specified ok";
+my $provdoc = Template::Provider->new({
+    ABSOLUTE => 1,
+    DOCUMENT => 'Test::Template::Document',
+    LOAD_TEMPLATES => [ $provabs ],
+}) || die $Template::Provider::ERROR;
+is $provdoc->{DOCUMENT}, 'Test::Template::Document', "Custom document class is specified ok";
+my ($doc_abs) = $provabs->fetch($absfile);
+my ($doc_oth) = $provdoc->fetch($absfile);
+is ref $doc_abs, 'Template::Document';
+is ref $doc_oth, 'Test::Template::Document';
 
+test_expect(\*DATA, $uselist, $vars);
 
 __DATA__
 -- test --


### PR DESCRIPTION
Resolves #173: The provider object already defines its own DOCUMENT class to
be used for creating a Template document. Other places in the code properly
reference the $self->{DOCUMENT}, this line seemed to have been overlooked when
the code was refactored.