### PR TITLE
Fix for rand call with no args in Math plugin.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -128,6 +128,7 @@ t/lib/Template/Plugin/Simple.pm
 t/list.t
 t/macro.t
 t/math.t
+t/math_rand.t
 t/object.t
 t/outline.t
 t/output.t

--- a/lib/Template/Plugin/Math.pm
+++ b/lib/Template/Plugin/Math.pm
@@ -52,10 +52,10 @@ sub hex   { shift; CORE::hex($_[0]);          }
 sub int   { shift; CORE::int($_[0]);          }
 sub log   { shift; CORE::log($_[0]);          }
 sub oct   { shift; CORE::oct($_[0]);          }
-sub rand  { shift; CORE::rand($_[0]);         }
+sub rand  { shift; @_ ? CORE::rand($_[0]) : CORE::rand(); }
 sub sin   { shift; CORE::sin($_[0]);          }
 sub sqrt  { shift; CORE::sqrt($_[0]);         }
-sub srand { shift; CORE::srand($_[0]);        }
+sub srand { shift; @_ ? CORE::srand($_[0]) : CORE::srand(); }
 
 # Use the Math::TrulyRandom module
 # XXX This is *sloooooooowwwwwwww*

--- a/t/math_rand.t
+++ b/t/math_rand.t
@@ -1,0 +1,19 @@
+use strict;
+use Test::More;
+use Template;
+
+plan tests => 1;
+
+my @warnings;
+local $SIG{__WARN__} = sub { push @warnings, @_ };
+my $t = Template->new;
+my $out;
+$t->process(\<<EOF, {}, \$out) or die $t->error;
+[% USE Math -%]
+rand  with arg:    [% Math.rand(1000000) %]
+rand  without arg: [% Math.rand %]
+srand with arg:    [% Math.srand(1000000) %]
+srand without arg: [% Math.srand %]
+EOF
+#diag $out;
+is_deeply \@warnings, [], 'No warnings when calling rand/srand without arg';


### PR DESCRIPTION
Resolves GH #155: Calling this without an arg caused the following error:
Use of uninitialized value $_[0] in rand at
/usr/lib/perl5/Template/Plugin/Math.pm line 55.

The issue is fixed and tests are added to confirm this works correctly in
the future.