### PR TITLE
Adjust Template::Plugin::Date::format to honor TZ and DST.

### DIFF
--- a/lib/Template/Plugin/Date.pm
+++ b/lib/Template/Plugin/Date.pm
@@ -91,10 +91,10 @@ sub format {
     if ($time =~ /^-?\d+$/) {
         # $time is now in seconds since epoch
         if ($gmt) {
-            @date = (gmtime($time))[0..6];
+            @date = (gmtime($time))[0..8];
         }
         else {
-            @date = (localtime($time))[0..6];
+            @date = (localtime($time))[0..8];
         }
     }
     else {


### PR DESCRIPTION
Resolves GH #132

Template::Plugin::Date::format() calls localtime() or gmtime() but only sets
```@date``` to the first 7 values (line 97):
    
```@date``` = (localtime($time))[0..6];
    
POSIX::strftime() defaults isdst (10th field) to -1:
    
strftime(fmt, sec, min, hour, mday, mon, year, wday = -1, yday = -1, isdst = -1)
    
When glibc's strftime() function is called, it will ignore attempting to
calculate the GMT offset when tm_isdst is <0:
        case L_('z'):
          if (tp->tm_isdst < 0)
            break;
    
Example:
perl -MPOSIX -e 'print POSIX::strftime("%F,%z\n", 59, 45, 12, 5, 0, 116, 2)'
2016-01-05,
    
perl -MPOSIX -e 'print POSIX::strftime("%F,%z\n", 59, 45, 12, 5, 0, 116, 2, 4, 0)'
2016-01-05,-0600