### PR TITLE
Set date to epoch when doing date.format(0)

### DIFF
--- a/lib/Template/Plugin/Date.pm
+++ b/lib/Template/Plugin/Date.pm
@@ -78,8 +78,10 @@ sub now {
 sub format {
     my $self   = shift;
     my $params = ref($_[$#_]) eq 'HASH' ? pop(@_) : { };
-    my $time   = shift(@_) || $params->{ time } || $self->{ time } 
-                           || $self->now();
+
+    my $time   = shift(@_);
+    $time = $params->{ time } || $self->{ time } || $self->now() if !defined $time;
+
     my $format = @_ ? shift(@_) 
                     : ($params->{ format } || $self->{ format } || $FORMAT);
     my $locale = @_ ? shift(@_)


### PR DESCRIPTION
Resolves GH #116

date.format(0) returns todays date not 01/01/1970
i.e. there needs to be a difference between
date.format(0)
and
date.format()