### PR TITLE
Re-save templates to disk if they have changed?

### DIFF
--- a/lib/Template/Provider.pm
+++ b/lib/Template/Provider.pm
@@ -711,7 +711,7 @@ sub _refresh {
                 if $self->{ DEBUG };
 
             ($data, $error) = $self->_load($slot->[ NAME ], $slot->[ DATA ]->{ name });
-            ($data, $error) = $self->_compile($data)
+            ($data, $error) = $self->_compile($data, $self->_compiled_filename($slot->[ NAME ]))
                 unless $error;
 
             if ($error) {
@@ -1010,7 +1010,7 @@ sub _template_content {
         local $/;
         binmode(FH);
         $data = <FH>;
-        $mod_date = (stat($path))[9];
+        $mod_date = $self->_template_modified($path);
         close(FH);
     }
     else {


### PR DESCRIPTION
Resolves GH #98

TT does not save compiled on-fly templates to disk (only saves firs-
time compiled)

and second line - for help hacking via redefining functions for bases,
preprocessing,..