### PR TITLE
Adjust group regexes to not be greedy

### DIFF
--- a/lib/Template/Context.pm
+++ b/lib/Template/Context.pm
@@ -761,11 +761,11 @@ sub debugging {
     my @args = @_;
 
     if (@args) {
-        if ($args[0] =~ /^on|1$/i) {
+        if ($args[0] =~ /^(on|1)$/i) {
             $self->{ DEBUG_DIRS } = 1;
             shift(@args);
         }
-        elsif ($args[0] =~ /^off|0$/i) {
+        elsif ($args[0] =~ /^(off|0)$/i) {
             $self->{ DEBUG_DIRS } = 0;
             shift(@args);
         }

--- a/lib/Template/Directive.pm
+++ b/lib/Template/Directive.pm
@@ -685,7 +685,7 @@ $block
     };
     if (\$@) {
         \$_tt_error = \$context->catch(\$@, \\\$output);
-        die \$_tt_error if \$_tt_error->type =~ /^return|stop\$/;
+        die \$_tt_error if \$_tt_error->type =~ /^(return|stop)\$/;
         \$stash->set('error', \$_tt_error);
         \$stash->set('e', \$_tt_error);
         if (defined (\$_tt_handler = \$_tt_error->select_handler($handlers))) {

--- a/lib/Template/Stash.pm
+++ b/lib/Template/Stash.pm
@@ -75,13 +75,13 @@ sub define_vmethod {
     my $op;
     $type = lc $type;
 
-    if ($type =~ /^scalar|item$/) {
+    if ($type =~ /^(scalar|item)$/) {
         $op = $SCALAR_OPS;
     }
     elsif ($type eq 'hash') {
         $op = $HASH_OPS;
     }
-    elsif ($type =~ /^list|array$/) {
+    elsif ($type =~ /^(list|array)$/) {
         $op = $LIST_OPS;
     }
     else {


### PR DESCRIPTION
GH #94

This is an issue spotted by dami@cpan.org
pointing that several regexes where too open
and could lead to some false positives.

Add parens to make them more strict.

References: RT 57539