### PR TITLE
Fix a circular reference in Template::Plugin::Filter

### DIFF
--- a/lib/Template/Plugin/Filter.pm
+++ b/lib/Template/Plugin/Filter.pm
@@ -49,6 +49,12 @@ sub new {
         _CONFIG  => $config,
     }, $class;
 
+
+    if ( defined $context ) {
+        # avoid circular reference and memory leak
+        weaken( $self->{_CONTEXT} );
+    }
+
     return $self->init($config)
         || $class->error($self->error());
 }

--- a/t/zz-plugin-cycle.t
+++ b/t/zz-plugin-cycle.t
@@ -1,0 +1,55 @@
+#============================================================= -*-perl-*-
+#
+# t/zz-plugin-cycle.t
+#
+# Check for memory leak when using Template::Plugin::Simple
+#
+# Written by Nicolas R. <atoomic@cpan.org>
+#
+# Copyright (C) 2018 cPanel Inc.  All Rights Reserved.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the same terms as Perl itself.
+#
+#========================================================================
+
+use strict;
+use lib qw( t/lib ./lib ../lib ../blib/arch );
+
+use Template;
+use Template::Plugin::Simple;
+
+use Test::More tests => 1;
+
+plan( skip_all => "Developer test" ) unless ( $ENV{AUTOMATED_TESTING} or $ENV{RELEASE_TESTING} );
+
+#use Test::LeakTrace;
+eval { require Test::LeakTrace };
+if ($@) {
+    skip_all('Test::LeakTrace not installed');
+}
+
+note "Searching for leak using Test::LeakTrace...";
+
+my $no_leaks = Test::LeakTrace::no_leaks_ok( \&plugin_simple_test, 'no leak from Template::Plugin' );
+
+if ( !$no_leaks ) {
+    diag "Memory leak detected...";
+
+    if ( eval { require Devel::Cycle; 1 } ) {
+        Devel::Cycle::find_cycle( plugin_simple_test() );
+    }
+    else {
+        diag "consider installing Devel::Cycle to detect leak";
+    }
+}
+
+exit;
+
+sub plugin_simple_test {
+    my $tpl = Template->new( PLUGIN_BASE => 'test' );
+    $tpl->context->plugin( 'Simple', [] );
+
+    return $tpl;
+}
+


### PR DESCRIPTION
GH #152

This is an issue reported by hiratara who detected
a memory leak in Template::Plugin::Filter.

This commit adds one extra dev test to check for memory
leak and report circular reference found, in order
to detect similar issues in the future.

The leak is fixed by using weaken on the context object
stored in Plugin::Filter.

References: RT 62045