### PR TITLE
No need to declare package bytes

### DIFF
--- a/lib/Template/Provider.pm
+++ b/lib/Template/Provider.pm
@@ -81,16 +81,6 @@ my $boms = [
 # regex to match relative paths
 our $RELATIVE_PATH = qr[(?:^|/)\.+/];
 
-
-# hack so that 'use bytes' will compile on versions of Perl earlier than
-# 5.6, even though we never call _decode_unicode() on those systems
-BEGIN {
-    if ($] < 5.006) {
-        $INC{'bytes.pm'} = 1;
-    }
-}
-
-
 #========================================================================
 #                         -- PUBLIC METHODS --
 #========================================================================

--- a/lib/Template/Provider.pm
+++ b/lib/Template/Provider.pm
@@ -86,7 +86,6 @@ our $RELATIVE_PATH = qr[(?:^|/)\.+/];
 # 5.6, even though we never call _decode_unicode() on those systems
 BEGIN {
     if ($] < 5.006) {
-        package bytes;
         $INC{'bytes.pm'} = 1;
     }
 }


### PR DESCRIPTION
Resolves #204

Avoid release permissions issues by removing
the 'package bytes'. We just try to avoid to load it.

Note: newline can also hide it from PAUSE but this is not
necessary in this case.