### PR TITLE
Add support for %z. Fix #132

### DIFF
--- a/t/date.t
+++ b/t/date.t
@@ -29,6 +29,7 @@ eval "use Date::Calc";
 my $got_date_calc = 0;
 $got_date_calc++ unless $@;
 
+local $ENV{TZ} = 'Europe/London';
 
 $Template::Test::DEBUG = 0;
 
@@ -273,3 +274,24 @@ not testing
 -%]
 -- expect --
 12:59
+
+-- test --
+[% USE date( use_offset = 1 );
+   date.format( '2001/09/30T12:59:00', '%H:%M %z' )
+-%]
+-- expect --
+12:59 +0100
+
+-- test --
+[% USE date( use_offset = 1 );
+   date.format( '2001/09/30T12:59:00', '%H:%M' )
+-%]
+-- expect --
+12:59
+
+-- test --
+[% USE date;
+   date.format( time = '2001/09/30T12:59:00', format = '%H:%M %z', use_offset = 1 )
+-%]
+-- expect --
+12:59 +0100


### PR DESCRIPTION
This is an attempt at solving #132 in a way that maintains backwards compatibility (and avoid the issues that blocked #192).

This is implemented not in a separate function, but with a separate `use_offset` parameter that can be set globally for those who like to live on the edge. The parameter can be set by name or as the fifth (!) parameter to `format`.

I am not entirely convinced on the name of the parameter, so I am open to suggestions for a better name. 

This contribution brought to you courtesy of the Pull Request Challenge. :)