### PR TITLE
do not weaken cyclic reference twice

### DIFF
--- a/lib/Template/Plugin/Filter.pm
+++ b/lib/Template/Plugin/Filter.pm
@@ -23,7 +23,7 @@ package Template::Plugin::Filter;
 use strict;
 use warnings;
 use base 'Template::Plugin';
-use Scalar::Util 'weaken';
+use Scalar::Util 'weaken', 'isweak';
 
 
 our $VERSION = 1.38;
@@ -65,7 +65,8 @@ sub factory {
     my $this = $self;
     
     # avoid a memory leak
-    weaken( $this->{_CONTEXT} ) if ref $this->{_CONTEXT};
+    weaken( $this->{_CONTEXT} ) if ref $this->{_CONTEXT}
+            && !isweak $this->{_CONTEXT};
 
     if ($self->{ _DYNAMIC }) {
         return [ sub {


### PR DESCRIPTION
Fixes #206.

The following minimal example reproduces the error:

```perl
package Template::Plugin::Echo;

use base qw(Template::Plugin::Filter);

sub filter {
        my ($self, $text) = @_;
        
        return $text . $text;
}

package main;

use Template;

# Make it look like an external file ...
$INC{'Template/Plugin/Echo.pm'} = 'whatever';

my $template = <<'EOF';
[%- USE Echo -%]
[% FILTER $Echo %]foo[% END %]
[% FILTER $Echo %]bar[% END %]
EOF

Template->new->process(\$template, {}) or die $Template::Error;
```

The warning "reference is already weak at ..." only appears if you use the `FILTER` more than once. The warning disappears if you remove the last line from `$template`.

The issue may look like a minor, cosmetic problem but in larger projects it is a major nuisance because you are getting flooded with warnings.