### PR TITLE
Add encoding option to Datafile plugin

### DIFF
--- a/lib/Template/Plugin/Datafile.pm
+++ b/lib/Template/Plugin/Datafile.pm
@@ -27,7 +27,7 @@ our $VERSION = '3.003';
 
 sub new {
     my ($class, $context, $filename, $params) = @_;
-    my ($delim, $line, @fields, @data, @results);
+    my ($delim, $encoding, $line, @fields, @data, @results);
     my $self = [ ];
     local *FD;
     local $/ = "\n";
@@ -35,11 +35,12 @@ sub new {
     $params ||= { };
     $delim = $params->{'delim'} || ':';
     $delim = quotemeta($delim);
+    $encoding = defined $params->{'encoding'} ? ':encoding('.$params->{'encoding'}.')' : '';
 
     return $class->error("No filename specified")
         unless $filename;
 
-    open(FD, '<', $filename)
+    open(FD, '<'.$encoding, $filename)
         || return $class->error("$filename: $!");
 
     # first line of file should contain field definitions

--- a/lib/Template/Plugin/Datafile.pm
+++ b/lib/Template/Plugin/Datafile.pm
@@ -93,6 +93,7 @@ Template::Plugin::Datafile - Plugin to construct records from a simple data file
 
     [% USE mydata = datafile('/path/to/datafile') %]
     [% USE mydata = datafile('/path/to/datafile', delim = '|') %]
+    [% USE mydata = datafile('/path/to/datafile', encoding = 'UTF-8') %]
     
     [% FOREACH record = mydata %]
        [% record.this %]  [% record.that %]
@@ -110,6 +111,8 @@ A absolute filename must be specified (for this initial implementation at
 least - in a future version it might also use the C<INCLUDE_PATH>).  An 
 optional C<delim> parameter may also be provided to specify an alternate
 delimiter character.
+The optional C<encoding> parameter may be used to specify the input file
+encoding.
 
     [% USE userlist = datafile('/path/to/file/users')     %]
     [% USE things   = datafile('items', delim = '|') %]


### PR DESCRIPTION
This PR add ability to specify 'encoding' option when opening file in the 'Datafile' plugin.

E.g. opening file in UTF-8 encoding:
[% USE file = datafile('foo.csv', encoding = 'UTF-8') %]
