### PR TITLE
Speed up Template Toolkit template by about 10% with single quotes

### DIFF
--- a/lib/Template/Directive.pm
+++ b/lib/Template/Directive.pm
@@ -150,14 +150,19 @@ sub textblock {
 #------------------------------------------------------------------------
 
 sub text {
-    my ($self, $text) = @_;
-    for ($text) {
-        s/(["\$\@\\])/\\$1/g;
-        s/\n/\\n/g;
-    }
-    return '"' . $text . '"';
-}
+    my ( $self, $text ) = @_;
 
+    return '' if !length $text;
+
+    if ( $text =~ tr{$@\\}{} ) {
+        $text =~ s/(["\$\@\\])/\\$1/g;
+        $text =~ s/\n/\\n/g;
+        return '"' . $text . '"';
+    }
+
+    $text =~ s{'}{\\'}g if index( $text, q{'} ) != -1;
+    return q{'} . $text . q{'};
+}
 
 #------------------------------------------------------------------------
 # quoted(\@items)                                               "foo$bar"

--- a/t/constants.t
+++ b/t/constants.t
@@ -77,7 +77,7 @@ die "parser error: ", $parser->error(), "\n"
 my $text = $parsed->{ BLOCK };
 
 ok( scalar $text =~ /'Andy \\'Da Man\\' Wardley'/, 'author folded' );
-ok( scalar $text =~ /"back is " . '#ffffff'/, 'col.back folded' );
+ok( scalar $text =~ /'back is ' . '#ffffff'/, 'col.back folded' );
 ok( scalar $text =~ /stash->get\(\['col', 0, 'user', 0\]\)/, 'col.user unfolded' );
 
 
@@ -101,7 +101,7 @@ die "parser error: ", $parser->error(), "\n"
 $text = $parsed->{ BLOCK };
 
 ok( scalar $text =~ /'Andy \\'Da Man\\' Wardley'/, 'author folded' );
-ok( scalar $text =~ /"back is " . '#ffffff'/, 'col.back folded' );
+ok( scalar $text =~ /'back is ' . '#ffffff'/, 'col.back folded' );
 ok( scalar $text =~ /stash->get\(\['col', 0, 'user', 0\]\)/, 'col.user unfolded' );
 
 #------------------------------------------------------------------------

--- a/t/fileline.t
+++ b/t/fileline.t
@@ -111,7 +111,7 @@ warn: [% warn %]
 Hello
 World
 file: (eval)
-line: 10
+line: 11
 warn: Argument "" isn't numeric in addition (+)
 
 -- test --


### PR DESCRIPTION
Because Perl has to do less work to parse a '' string than a "" string, we
can detect this and generate '' when rendering the template.

This change may require more tests.