### PR TITLE
Avoid destruction segfault on Template objects

### DIFF
--- a/lib/Template/Base.pm
+++ b/lib/Template/Base.pm
@@ -138,6 +138,7 @@ sub module_version {
     return ${"${class}::VERSION"};
 }
 
+sub DESTROY { 1 } # noop
 
 1;
 


### PR DESCRIPTION
Compiled code using Template::Toolkit object
segfault during fast_destroy.

The stash cache is corrupted, for one unknown
reason. Provide an empty DESTROY sub to Template::Base