### PR TITLE
Ensure we only load plugins once per context

### DIFF
--- a/lib/Template/Context.pm
+++ b/lib/Template/Context.pm
@@ -187,11 +187,16 @@ sub plugin {
     
     $self->debug("plugin($name, ", defined $args ? @$args : '[ ]', ')')
         if $self->{ DEBUG };
-    
+
+    return $self->{ _PLUGIN_CONTEXT_CACHE }{$name} if !$args && $self->{ _PLUGIN_CONTEXT_CACHE }{$name};
+
     # request the named plugin from each of the LOAD_PLUGINS providers in turn
     foreach my $provider (@{ $self->{ LOAD_PLUGINS } }) {
         ($plugin, $error) = $provider->fetch($name, $args, $self);
-        return $plugin unless $error;
+        unless($error) {
+          $self->{ _PLUGIN_CONTEXT_CACHE }{$name} = $plugin if !$args;
+          return $plugin;
+        }
         if ($error == Template::Constants::STATUS_ERROR) {
             $self->throw($plugin) if ref $plugin;
             $self->throw(Template::Constants::ERROR_PLUGIN, $plugin);


### PR DESCRIPTION
Template::Toolkit lacked the logic to determine if a plugin is
already loaded into a context and will reload the plugin every
time it sees a USE statement.