### PR TITLE
Remove 'use vars' and drop officialy 5.6 support.

### DIFF
--- a/Changes
+++ b/Changes
@@ -18,6 +18,8 @@
 # Version 3.000 - 23rd December 2019
 #------------------------------------------------------------------------
 
+* Remove 'use vars' and drop officialy 5.6 support.
+
 * Bump all packages versions to 3.000
 
 * Switch to github actions for CI testing

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use 5.006;
+use 5.008;
 use lib qw( ./lib );
 use Config;
 use File::Spec::Functions qw( catfile );
@@ -15,9 +15,10 @@ select STDERR;
 $| = 1;
 select STDOUT;
 
-use vars qw( $TT_VERSION $TT_PREFIX
-             $TT_XS_ENABLE $TT_XS_DEFAULT
-             $TT_QUIET $TT_ACCEPT $TT_YES );
+our ( $TT_VERSION, $TT_PREFIX,
+      $TT_XS_ENABLE, $TT_XS_DEFAULT,
+      $TT_QUIET, $TT_ACCEPT, $TT_YES
+);
 
 # check O/S to set sensible defaults
 

--- a/lib/Template/Config.pm
+++ b/lib/Template/Config.pm
@@ -21,29 +21,32 @@ package Template::Config;
 use strict;
 use warnings;
 use base 'Template::Base';
-use vars qw( $VERSION $DEBUG $ERROR $INSTDIR
-             $PARSER $PROVIDER $PLUGINS $FILTERS $ITERATOR 
-             $LATEX_PATH $PDFLATEX_PATH $DVIPS_PATH
-             $STASH $SERVICE $CONTEXT $CONSTANTS @PRELOAD );
 
-$VERSION   = '3.000';
+our $VERSION   = '3.000';
+
+our $DEBUG;
 $DEBUG     = 0 unless defined $DEBUG;
-$ERROR     = '';
-$CONTEXT   = 'Template::Context';
-$FILTERS   = 'Template::Filters';
-$ITERATOR  = 'Template::Iterator';
-$PARSER    = 'Template::Parser';
-$PLUGINS   = 'Template::Plugins';
-$PROVIDER  = 'Template::Provider';
-$SERVICE   = 'Template::Service';
+our $ERROR     = '';
+our $CONTEXT   = 'Template::Context';
+our $FILTERS   = 'Template::Filters';
+our $ITERATOR  = 'Template::Iterator';
+our $PARSER    = 'Template::Parser';
+our $PLUGINS   = 'Template::Plugins';
+our $PROVIDER  = 'Template::Provider';
+our $SERVICE   = 'Template::Service';
+our $STASH;
 $STASH     = 'Template::Stash::XS';
-$CONSTANTS = 'Template::Namespace::Constants';
+our $CONSTANTS = 'Template::Namespace::Constants';
 
-@PRELOAD   = ( $CONTEXT, $FILTERS, $ITERATOR, $PARSER,
+our $LATEX_PATH;
+our $PDFLATEX_PATH;
+our $DVIPS_PATH;
+
+our @PRELOAD   = ( $CONTEXT, $FILTERS, $ITERATOR, $PARSER,
                $PLUGINS, $PROVIDER, $SERVICE, $STASH );
 
 # the following is set at installation time by the Makefile.PL 
-$INSTDIR  = '';
+our $INSTDIR  = '';
 
 
 #========================================================================

--- a/lib/Template/Constants.pm
+++ b/lib/Template/Constants.pm
@@ -22,15 +22,13 @@ require Exporter;
 use strict;
 use warnings;
 use Exporter;
-# Perl::MinimumVersion seems to think this is a Perl 5.008ism...
-# use base qw( Exporter );
-use vars qw( @EXPORT_OK %EXPORT_TAGS );
-use vars qw( $DEBUG_OPTIONS @STATUS @ERROR @CHOMP @DEBUG @ISA );
-# ... so we'll do it the Old Skool way just to keep it quiet
-@ISA = qw( Exporter );
+
+use base qw( Exporter );
+
+our ( @EXPORT_OK, %EXPORT_TAGS );
+our ( $DEBUG_OPTIONS, @STATUS, @ERROR, @CHOMP, @DEBUG, @ISA );
 
 our $VERSION = '3.000';
-
 
 #========================================================================
 #                         ----- EXPORTER -----

--- a/lib/Template/Plugin/Date.pm
+++ b/lib/Template/Plugin/Date.pm
@@ -178,7 +178,7 @@ sub throw {
 
 package Template::Plugin::Date::Calc;
 use base qw( Template::Plugin );
-use vars qw( $AUTOLOAD );
+our $AUTOLOAD;
 *throw = \&Template::Plugin::Date::throw;
 
 sub AUTOLOAD {
@@ -197,7 +197,7 @@ sub AUTOLOAD {
 
 package Template::Plugin::Date::Manip;
 use base qw( Template::Plugin );
-use vars qw( $AUTOLOAD );
+our $AUTOLOAD;
 *throw = \&Template::Plugin::Date::throw;
 
 sub AUTOLOAD {

--- a/lib/Template/Tutorial/Web.pod
+++ b/lib/Template/Tutorial/Web.pod
@@ -525,12 +525,11 @@ module.  That module might look something like this:
     package MyOrg::Apache::User;
     
     use strict;
-    use vars qw( $VERSION );
     use Apache::Constants qw( :common );
     use Template qw( :template );
     use CGI;
     
-    $VERSION = 1.59;
+    our $VERSION = 1.59;
     
     sub handler {
         my $r = shift;

--- a/t/base.t
+++ b/t/base.t
@@ -28,7 +28,7 @@ ntests(24);
 #------------------------------------------------------------------------
 package Template::Fail;
 use base qw( Template::Base );
-use vars qw( $ERROR );
+our $ERROR;
 use Template::Base;
 
 sub _init {
@@ -42,7 +42,7 @@ sub _init {
 #------------------------------------------------------------------------
 package Template::Named;
 use base qw( Template::Base );
-use vars qw( $ERROR );
+our $ERROR;
 use Template::Base;
 
 sub _init {
@@ -63,7 +63,7 @@ sub name {
 package Template::Version;
 use Template::Base;
 use base qw( Template::Base );
-use vars qw( $ERROR $VERSION );
+our ( $ERROR, $VERSION );
 $VERSION = 3.14;
 
 

--- a/t/config.t
+++ b/t/config.t
@@ -18,7 +18,7 @@
 
 use strict;
 use lib  qw( ./lib ../lib );
-use vars qw( $DEBUG );
+our $DEBUG;
 use Template::Test;
 use Template::Config;
 

--- a/t/dumper.t
+++ b/t/dumper.t
@@ -15,7 +15,7 @@
 
 use strict;
 use lib qw( ./lib ../lib );
-use vars qw( $DEBUG );
+our $DEBUG;
 use Template::Test;
 $^W = 1;
 

--- a/t/leak.t
+++ b/t/leak.t
@@ -30,7 +30,7 @@ $Template::Test::PRESERVE = 1;
 
 #------------------------------------------------------------------------
 package Holler;
-use vars qw( $TRACE $PREFIX );
+our ( $TRACE, $PREFIX );
 $TRACE = '';
 $PREFIX = 'Holler:';
 

--- a/t/object.t
+++ b/t/object.t
@@ -40,7 +40,7 @@ sub die {
 
 package TestObject;
 
-use vars qw( $AUTOLOAD );
+our $AUTOLOAD;
 
 sub new {
     my ($class, $params) = @_;

--- a/t/output.t
+++ b/t/output.t
@@ -83,7 +83,7 @@ unlink($file2);
 package My::Template;
 use Template;
 use base qw( Template );
-use vars qw( $MESSAGE );
+our $MESSAGE;
 
 sub DEBUG {
     my $self = shift;

--- a/t/stop.t
+++ b/t/stop.t
@@ -18,7 +18,7 @@
 
 use strict;
 use lib qw( ./lib ../lib ../blib/lib ../blib/arch ./blib/lib ./blib/arch );
-use vars qw( $DEBUG );
+our $DEBUG;
 use Template::Test;
 use Template::Parser;
 use Template::Exception;

--- a/todo_misc/cache_plugin
+++ b/todo_misc/cache_plugin
@@ -116,13 +116,12 @@ Content-Disposition: inline;
 package Template::Plugin::Cache;
 
 use strict;
-use vars qw( $VERSION );
 use base qw( Template::Plugin );
 use Template::Plugin;
 
 use File::Cache;
 
-$VERSION = 0.1;
+our $VERSION = 0.1;
 
 #------------------------------------------------------------------------
 # new(\%options)


### PR DESCRIPTION
We are already using some features which are
failing with 5.6.