### PR TITLE
Do not cache plugin with filters

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,8 +60,8 @@ jobs:
         run: $CPM_INSTALL_PLUGIN Template::Plugin::CSV
       - name: Template::Plugin::URI
         run: $CPM_INSTALL_PLUGIN Template::Plugin::URI
-      # - name: Template::Plugin::Autoformat
-      #   run: $CPM_INSTALL_PLUGIN Template::Plugin::Autoformat
+      - name: Template::Plugin::Autoformat
+        run: $CPM_INSTALL_PLUGIN Template::Plugin::Autoformat
       # - name: Template-DBI
       #   run: $CPM_INSTALL_PLUGIN Template::Plugin::DBI
       # - name: Template::Plugin::Map

--- a/cpanfile
+++ b/cpanfile
@@ -14,4 +14,7 @@ on "test" => sub {
         requires "Test::Builder"             => 0;
         requires "Test::CPAN::Meta"          => 0;
         requires "Test::More"                => 0;
+
+        # required for testing some plugins on 5.8
+        requires "Module::Build"             => 0;
 };


### PR DESCRIPTION
References #241

We cannot cache Autoformat plugin as
it contains some filters which would
not be reset on the second load.

This is a follow up to commit
282109bf1a49ef8c0848a31d960260a116d91a4f