### PR TITLE
Typo fix in Variables.pod

### DIFF
--- a/lib/Template/Manual/Variables.pod
+++ b/lib/Template/Manual/Variables.pod
@@ -496,7 +496,7 @@ most common use is to retrieve an element from a hash where the key is
 stored in a variable.
 
     [% uid = 'abw' %]
-    [% users.$uid %]         # same as 'userlist.abw'
+    [% users.$uid %]         # same as 'users.abw'
 
 Curly braces can be used to delimit interpolated variable names where
 necessary.


### PR DESCRIPTION
I had noticed that one of the comments didn't match the content that it was referring to.

P.S. Happy New Year