### PR TITLE
ttree: Implement assets directories.

### DIFF
--- a/bin/ttree
+++ b/bin/ttree
@@ -75,6 +75,7 @@ my $suffix   = $config->suffix;
 my $binmode  = $config->binmode;
 my $depends  = $config->depend;
 my $depsfile = $config->depend_file;
+my $assets   = $config->assets;
 my ($n_proc, $n_unmod, $n_skip, $n_copy, $n_link, $n_mkdir) = (0) x 6;
 
 my $srcdir   = $config->src
@@ -191,6 +192,7 @@ if ($verbose) {
           "      Ignore: [ @$ignore ]\n",
           "        Copy: [ @$copy ]\n",
           "        Link: [ @$link ]\n",
+          "      Assets: [ @$assets ]\n",
           "      Accept: [ @$accept ]\n",
           "      Suffix: [ $sfx ]\n");
     print("      Module: $ttmodule ", $ttmodule->module_version(), "\n")
@@ -360,14 +362,26 @@ sub process_file {
     $dest = $destdir ? "$destdir/$destfile" : $destfile;
                    
 #    print "proc $file => $dest\n";
-    
-    # check against link list
-    foreach my $link_pattern (@$link) {
-        if ($filename =~ /$link_pattern/) {
-            $link_file = $copy_file = 1;
-            $check = $link_pattern;
-            last;
-        }
+
+    unless ($link_file) {
+	# check against link list
+	foreach my $link_pattern (@$link) {
+	    if ($filename =~ /$link_pattern/) {
+		$link_file = $copy_file = 1;
+		$check = "/$link_pattern/";
+		last;
+	    }
+	}
+    }
+
+    unless ($link_file) {
+	foreach my $asset_prefix (@$assets) {
+	    if ( index($file, "$asset_prefix/") == 0 ) {
+		$copy_file = 1;
+		$check = "assets: $asset_prefix";
+		last;
+	    }
+	}
     }
 
     unless ($copy_file) {
@@ -375,7 +389,7 @@ sub process_file {
         foreach my $copy_pattern (@$copy) {
             if ($filename =~ /$copy_pattern/) {
                 $copy_file = 1;
-                $check = $copy_pattern;
+                $check = "/$copy_pattern/";
                 last;
             }
         }
@@ -429,7 +443,7 @@ sub process_file {
 
         unless ($copy_file) {
             $n_link++;
-            printf green("  > %-32s (linked, matches /$check/)\n"), $file
+            printf green("  > %-32s (linked, matches $check)\n"), $file
                 if $verbose;
             return;
         }
@@ -447,7 +461,7 @@ sub process_file {
             }
         }
 
-        printf green("  > %-32s (copied, matches /$check/)\n"), $file
+        printf green("  > %-32s (copied, matches $check)\n"), $file
             if $verbose;
 
         return;
@@ -614,6 +628,7 @@ sub read_config {
         'depend=s%',
         'depend_debug|depdbg',
         'depend_file|depfile=s' => { EXPAND => EXPAND_ALL },
+        'assets=s@',
         'template_module|module=s',
         'template_anycase|anycase',
         'template_encoding|encoding=s',
@@ -810,6 +825,7 @@ File search specifications (all may appear multiple times):
    --ignore=REGEX           Ignore files matching REGEX
    --copy=REGEX             Copy files matching REGEX
    --link=REGEX             Link files matching REGEX
+   --assets=DIR             Copy files in assets dir DIR
    --accept=REGEX           Process only files matching REGEX 
 
 File Dependencies Options:
@@ -1051,7 +1067,8 @@ The C<ignore>, C<copy>, C<link> and C<accept> options are used to
 specify Perl regexen to filter file names. Files that match any of the
 C<ignore> options will not be processed. Remaining files that match
 any of the C<copy> or C<link> regexen will be copied or linked to the
-destination directory. Remaining files that then match any of the
+destination directory. Files that reside in any of the C<assets>
+ directories are also copied. Remaining files that then match any of the
 C<accept> criteria are then processed via the Template Toolkit. If no
 C<accept> parameter is specified then all files will be accepted for
 processing if not already copied or ignored.


### PR DESCRIPTION
This PR implements assets directories in ttree.

Assets directories are directories that contain assets, fixed (static) materials that are not to be processed by Template, but always copied 'as is'. Common use is for static images, icons, documentation files, videos and so on.

The PR adds the keyword `assets` and corresponding command line option `--assets` that can be used to name a directory that contains assets. This directory must reside directly under the top of the source tree. Multiple directories can be specified by repeating the keyword or command line option.

When asset directories are specified, all files in these directories are copied with two exceptions:

* filenames that match any of the ignore patterns are ignored
* filenames that match any of the link patterns are linked

Note that suffix mapping still applies. I'm not sure if this is desired.