### PR TITLE
Avoid anonymous hash warnings starting with Perl 5.35.2

### DIFF
--- a/lib/Template/Document.pm
+++ b/lib/Template/Document.pm
@@ -72,7 +72,10 @@ sub new {
         $COMPERR = '';
 
         # DON'T LOOK NOW! - blindly untainting can make you go blind!
-        $block = each %{ { $block => undef } } if ${^TAINT};    #untaint
+        {
+            no warnings 'syntax';
+            $block = each %{ { $block => undef } } if ${^TAINT};    #untaint
+        }
 
         $block = eval $block;
         return $class->error($@)

--- a/lib/Template/Provider.pm
+++ b/lib/Template/Provider.pm
@@ -370,7 +370,10 @@ sub _init {
             next if ref $dir;
             my $wdir = $dir;
             $wdir =~ tr[:][]d if MSWin32;
-            $wdir = each %{ { $wdir => undef } } if ${^TAINT};    #untaint
+            {
+                no warnings 'syntax';
+                $wdir = each %{ { $wdir => undef } } if ${^TAINT};    #untaint
+            }
             $wdir = File::Spec->catfile($cdir, $wdir);
             File::Path::mkpath($wdir) unless -d $wdir;
         }
@@ -869,7 +872,10 @@ sub _compile {
         # write the Perl code to the file $compfile, if defined
         if ($compfile) {
             my $basedir = &File::Basename::dirname($compfile);
-            $basedir = each %{ { $basedir => undef } } if ${^TAINT};    #untaint
+            {
+                no warnings 'syntax';
+                $basedir = each %{ { $basedir => undef } } if ${^TAINT};    #untaint
+            }
 
             unless (-d $basedir) {
                 eval { File::Path::mkpath($basedir) };
@@ -888,7 +894,10 @@ sub _compile {
             # set atime and mtime of newly compiled file, don't bother
             # if time is undef
             if (!defined($error) && defined $data->{ 'time' }) {
-                my $cfile = each %{ { $compfile => undef } };
+                my $cfile = do {
+                    no warnings 'syntax';
+                    each %{ { $compfile => undef } };
+                };
                 if (!length $cfile) {
                     return("invalid filename: $compfile",
                            Template::Constants::STATUS_ERROR);


### PR DESCRIPTION
This silences these warnings:

t/compile1.t ................. each on anonymous hash will always start from the beginning at lib/Template/Document.pm line 75.
each on anonymous hash will always start from the beginning at lib/Template/Provider.pm line 373.
each on anonymous hash will always start from the beginning at lib/Template/Provider.pm line 872.
each on anonymous hash will always start from the beginning at lib/Template/Provider.pm line 891.

when compiling Template.  These warnings are still generated as of 5.35.4

@trwyant had alternate suggestions in #287 which also may be fine, but I needed to make these changes in my environment now and figured I may as well make it a PR while I was at it.  If you want a different implementation no harm in closing this.