### PR TITLE
Fix manual. Added info about accessing values with comples keys from hash

### DIFF
--- a/lib/Template/Manual/Variables.pod
+++ b/lib/Template/Manual/Variables.pod
@@ -182,6 +182,15 @@ L<Variable Interpolation>).
     [% pagename = 'next' %]
     [% page.$pagename %]       # same as [% page.next %]
 
+You can also access hash entry using C<item()> method. This might be helpful
+if you have complex key name.
+
+    <pre>
+    [% files.item('example.txt').content %]
+    </pre>
+
+See L<Template::Manual::VMethods|Template::Manual::VMethods/"item"> for more info.
+
 When you assign to a variable that contains multiple namespace
 elements (i.e. it has one or more 'C<.>' characters in the name),
 any hashes required to represent intermediate namespaces will be


### PR DESCRIPTION
I found out that Variables manual, do not have info how to address hash element with complex key , like `example.txt` for example 

This might cause real problem for Template Toolkit newbie. So I'd suggest a fix that adds another method of accessing hash value from hash to the Variables pod.

PS. Please refer me as Nikolay Shaplov (NATARAJ) in changelog, if you ever will refer me... 