### PR TITLE
remove extraneous arguments when loading Template

### DIFF
--- a/lib/Template/Test.pm
+++ b/lib/Template/Test.pm
@@ -23,7 +23,7 @@ package Template::Test;
 
 use strict;
 use warnings;
-use Template qw( :template );
+use Template;
 use Exporter;
 
 use constant MSWin32 => $^O eq 'MSWin32';

--- a/lib/Template/Tutorial/Web.pod
+++ b/lib/Template/Tutorial/Web.pod
@@ -526,7 +526,7 @@ module.  That module might look something like this:
     
     use strict;
     use Apache::Constants qw( :common );
-    use Template qw( :template );
+    use Template;
     use CGI;
     
     our $VERSION = 1.59;


### PR DESCRIPTION
Template has never had an import method, so passing arguments to it is pointless. The import call has always just been ignored by perl, but in the future it will trigger an error if given unhandled arguments.