### PR TITLE
Correct the path splitting on Win32

### DIFF
--- a/lib/Template/Provider.pm
+++ b/lib/Template/Provider.pm
@@ -335,7 +335,7 @@ sub _init {
 
     # tweak delim to ignore C:/
     unless (defined $dlim) {
-        $dlim = MSWin32 ? ':(?!\\/)' : ':';
+        $dlim = MSWin32 ? qr/:(?!\\|\/)/ : qr/:/;
     }
 
     # coerce INCLUDE_PATH to an array ref, if not already so


### PR DESCRIPTION
This is a fix for #158 as the regex that was used on Windows was not correct (it was missing an alternation between the slash and backslash).