### PR TITLE
Allow outline tags to be placed after horizontal whitespace

### DIFF
--- a/lib/Template/Parser.pm
+++ b/lib/Template/Parser.pm
@@ -282,7 +282,7 @@ sub text_splitter {
           \A(.*?)             # $1 - start of line up to directive
             (?:
               (?:
-              ^$out           # outline tag at start of line
+              ^\V*$out        # outline tag at start of line (with optional whitespace)
               (.*?            # $2 - content of that line
                 (?:\n|$)      # end of that line or file
               )

--- a/t/outline.t
+++ b/t/outline.t
@@ -117,3 +117,11 @@ e is not set
 $ END
 -- expect --
 e is set to echo
+
+-- test --
+-- name optional whitespace before outline tag --
+-- use outline --
+    %% a
+	%% b
+-- expect --
+alphabravo


### PR DESCRIPTION
I think this fixes what I described in the issue. Let me know if there's anything else I have to do before it's merged.

Resolves #320 