### PR TITLE
document  configuration

### DIFF
--- a/bin/tpage
+++ b/bin/tpage
@@ -190,6 +190,7 @@ Options:
    --template_module=MODULE Specify alternate Template module
    --while_max=INTEGER      Change '\$Template::Directive::WHILE_MAX' default
    --envvars                Set the 'env' variable to the environment (%ENV)
+   --expose_blocks          Make blocks visible as pseudo-files
 
 See 'perldoc tpage' for further information.  
 

--- a/lib/Template/App/ttree.pm
+++ b/lib/Template/App/ttree.pm
@@ -1013,6 +1013,9 @@ Additional options to set Template Toolkit configuration items:
    --compile_dir=DIR        Directory for compiled template files
    --perl5lib=DIR           Specify additional Perl library directories
    --template_module=MODULE Specify alternate Template module
+   --expose_blocks          Make blocks visible as pseudo-files
+
+
 
 See 'perldoc ttree' for further information.
 

--- a/lib/Template/Manual/Config.pod
+++ b/lib/Template/Manual/Config.pod
@@ -565,6 +565,31 @@ The template processor will raise a file exception if it detects
 direct or indirect recursion into a template.  Setting this option to
 any true value will allow templates to include each other recursively.
 
+=head2 EXPOSE_BLOCKS
+
+The C<EXPOSE_BLOCKS> option is unset by default and will make C<BLOCK>s
+in templates visible as pseudo-files under the C<template name> virtual
+directory.
+
+This enables the L<fragment pattern|https://htmx.org/essays/template-fragments/>,
+allowing partial rendering of a template, or rendering of a named section of a 
+template.
+
+Given the following template file (named F<index.html>)
+
+	<html>
+		[% BLOCK frag %]
+			[% DEFAULT text="hello world" %]
+			<div>[% text | html %]</div>
+		[% END %]
+		[% PROCESS frag %]
+		[% PROCESS frag text="foo is the new bar" %]
+	</html>
+
+when processed as F<index.html> will output the 2 C<div>s wrapped in C<html> tags,
+but when processed as F<index.html/frag>, will output only the C<div> from the 
+F<frag> C<BLOCK>.
+		
 =head1 Template Variables
 
 =head2 VARIABLES


### PR DESCRIPTION
document the EXPOSE_BLOCKS config option and `tpage` and `ttree` command options,  no code changes, only documentation