### PR TITLE
Ship Template::Plugin::List (fix #439)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -49,6 +49,7 @@ lib/Template/Plugin/Format.pm
 lib/Template/Plugin/HTML.pm
 lib/Template/Plugin/Image.pm
 lib/Template/Plugin/Iterator.pm
+lib/Template/Plugin/List.pm
 lib/Template/Plugin/Math.pm
 lib/Template/Plugin/Pod.pm
 lib/Template/Plugin/Procedural.pm

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -31,7 +31,6 @@
 ^lib/Template/Arena
 ^lib/Template/Map
 ^lib/Template/Plugin/XML/View
-^lib/Template/Plugin/List
 
 # Maintainer-only scripts
 ^bin/prep


### PR DESCRIPTION
## Summary
- Removes the obsolete `^lib/Template/Plugin/List` line from `MANIFEST.SKIP` so `lib/Template/Plugin/List.pm` is now included in the distribution.
- Regenerates `MANIFEST` via `make manifest` to add the entry.

## Background
The skip pattern was added by Andy Wardley in commit `c7dfeda1b` (2002-03-12) one minute before he committed `List.pm` itself in `bd08966f` with the message *"added Math and List plugins (not in main distribution yet)"*. The pattern was meant for an experimental `lib/Template/Plugin/List/` directory but — being unanchored — also matched `List.pm`. As a result the plugin has never shipped to CPAN in ~24 years, even though `t/plugin_list.t` was already in `MANIFEST` and references it.

Reported in #439 by @veryrusty: installing 3.105 from CPAN fails because the test exists but the module does not.

## Test plan
- [x] `make manifest` regenerates `MANIFEST` cleanly with `lib/Template/Plugin/List.pm` added
- [x] `make test` passes locally
- [x] Trial release / `make dist` tarball contains `lib/Template/Plugin/List.pm`

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)